### PR TITLE
Add docs link

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -72,6 +72,10 @@
 						<a href="https://community.umaproject.org" target="_blank">Community</a>
 					</li>
 
+                                        <li>
+                                                <a href="https://docs.umaproject.org" target="_blank">Documentation</a>
+                                        </li>
+
 					<li>
 						<a href="https://github.com/umaprotocol" target="_blank">GitHub</a>
 					</li>
@@ -274,7 +278,7 @@
 
 								<p class="profile__links">
 									<a href="https://www.linkedin.com/in/jillrcarlson/" target="_blank">LinkedIn</a>
-									<a href="https://twitter.com/_jillruth" target="_blank">Twitter</a>
+									<a href="https://twitter.com/jillruthcarlson" target="_blank">Twitter</a>
 								</p><!-- /.profile__links -->
 							</div><!-- /.profile__content -->
 						</div><!-- /.profile -->
@@ -443,6 +447,10 @@
 						<li>
 							<a href="https://community.umaproject.org" target="_blank">Community</a>
 						</li>
+
+                                                <li>
+                                                        <a href="https://docs.umaproject.org" target="_blank">Documentation</a>
+                                                </li>
 
 						<li>
 							<a href="https://github.com/umaprotocol" target="_blank">GitHub</a>

--- a/docs/about.html
+++ b/docs/about.html
@@ -73,7 +73,7 @@
 					</li>
 
                                         <li>
-                                                <a href="https://docs.umaproject.org" target="_blank">Documentation</a>
+                                                <a href="https://docs.umaproject.org" target="_blank">Docs</a>
                                         </li>
 
 					<li>
@@ -449,7 +449,7 @@
 						</li>
 
                                                 <li>
-                                                        <a href="https://docs.umaproject.org" target="_blank">Documentation</a>
+                                                        <a href="https://docs.umaproject.org" target="_blank">Docs</a>
                                                 </li>
 
 						<li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -72,6 +72,10 @@
 						<a href="https://community.umaproject.org" target="_blank">Community</a>
 					</li>
 
+                                        <li>
+                                                <a href="https://docs.umaproject.org" target="_blank">Documentation</a>
+                                        </li>
+
 					<li>
 						<a href="https://github.com/umaprotocol" target="_blank">GitHub</a>
 					</li>
@@ -346,6 +350,10 @@
 						<li>
 							<a href="https://community.umaproject.org" target="_blank">Community</a>
 						</li>
+
+                                                <li>
+                                                        <a href="https://docs.umaproject.org" target="_blank">Documentation</a>
+                                                </li>
 
 						<li>
 							<a href="https://github.com/umaprotocol" target="_blank">GitHub</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -73,7 +73,7 @@
 					</li>
 
                                         <li>
-                                                <a href="https://docs.umaproject.org" target="_blank">Documentation</a>
+                                                <a href="https://docs.umaproject.org" target="_blank">Docs</a>
                                         </li>
 
 					<li>
@@ -352,7 +352,7 @@
 						</li>
 
                                                 <li>
-                                                        <a href="https://docs.umaproject.org" target="_blank">Documentation</a>
+                                                        <a href="https://docs.umaproject.org" target="_blank">Docs</a>
                                                 </li>
 
 						<li>

--- a/src/partials/footer-smaller.html
+++ b/src/partials/footer-smaller.html
@@ -16,6 +16,10 @@
 							<a href="https://community.umaproject.org" target="_blank">Community</a>
 						</li>
 
+                                                <li>
+                                                        <a href="https://docs.umaproject.org" target="_blank">Documentation</a>
+                                                </li>
+
 						<li>
 							<a href="https://github.com/umaprotocol" target="_blank">GitHub</a>
 						</li>

--- a/src/partials/footer-smaller.html
+++ b/src/partials/footer-smaller.html
@@ -17,7 +17,7 @@
 						</li>
 
                                                 <li>
-                                                        <a href="https://docs.umaproject.org" target="_blank">Documentation</a>
+                                                        <a href="https://docs.umaproject.org" target="_blank">Docs</a>
                                                 </li>
 
 						<li>

--- a/src/partials/footer.html
+++ b/src/partials/footer.html
@@ -41,6 +41,10 @@
 							<a href="https://community.umaproject.org" target="_blank">Community</a>
 						</li>
 
+                                                <li>
+                                                        <a href="https://docs.umaproject.org" target="_blank">Documentation</a>
+                                                </li>
+
 						<li>
 							<a href="https://github.com/umaprotocol" target="_blank">GitHub</a>
 						</li>

--- a/src/partials/footer.html
+++ b/src/partials/footer.html
@@ -42,7 +42,7 @@
 						</li>
 
                                                 <li>
-                                                        <a href="https://docs.umaproject.org" target="_blank">Documentation</a>
+                                                        <a href="https://docs.umaproject.org" target="_blank">Docs</a>
                                                 </li>
 
 						<li>

--- a/src/partials/header.html
+++ b/src/partials/header.html
@@ -28,7 +28,7 @@
 					</li>
 
                                         <li>
-                                                <a href="https://docs.umaproject.org" target="_blank">Documentation</a>
+                                                <a href="https://docs.umaproject.org" target="_blank">Docs</a>
                                         </li>
 
 					<li>

--- a/src/partials/header.html
+++ b/src/partials/header.html
@@ -27,6 +27,10 @@
 						<a href="https://community.umaproject.org" target="_blank">Community</a>
 					</li>
 
+                                        <li>
+                                                <a href="https://docs.umaproject.org" target="_blank">Documentation</a>
+                                        </li>
+
 					<li>
 						<a href="https://github.com/umaprotocol" target="_blank">GitHub</a>
 					</li>


### PR DESCRIPTION
In the process of building this change, a twitter link change from the previous commit was also applied to the `docs/` folder.

We might want to wait on merging this until we have a full intro page deployed to the docs site.