### PR TITLE
fix(website): make tvl request fire immediately

### DIFF
--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -17,5 +17,6 @@ import handleFormSubmit from "./modules/handle-form-submit.js";
 import fetchTvl from "./modules/fetch-tvl";
 
 handleFormSubmit();
-const fiveMinutesInMilliseconds = 1000 * 60 * 5;
+fetchTvl();
+const fiveMinutesInMilliseconds = 1000 * 5 * 60;
 setInterval(() => fetchTvl(), fiveMinutesInMilliseconds);

--- a/src/assets/js/modules/fetch-tvl.js
+++ b/src/assets/js/modules/fetch-tvl.js
@@ -2,6 +2,7 @@ const tvlUrl = "https://api.umaproject.org/uma-tvl";
 const format = Intl.NumberFormat("en-US", {
   currency: "USD",
   style: "currency",
+  minimumFractionDigits: 0,
   maximumFractionDigits: 0,
 }).format;
 


### PR DESCRIPTION
This PR makes the `fetchTvl` function fire immediately after the page loads

Signed-off-by: Francesco Baccetti <gamarantor@gmail.com>