### PR TITLE
fix: close mobile menu on link click

### DIFF
--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -23,8 +23,8 @@ const NavLinks = () => {
 export const Header: React.FunctionComponent = () => {
   const [showMobileMenu, setShowMobileMenu] = useState(false);
 
-  const onToggle = (toggled: boolean) => {
-    setShowMobileMenu(toggled);
+  const onToggle = () => {
+    setShowMobileMenu((prevShowMobileMenu) => !prevShowMobileMenu);
   }
 
   return (
@@ -36,19 +36,19 @@ export const Header: React.FunctionComponent = () => {
         <UI.NavContainer>
           <NavLinks />
         </UI.NavContainer>
-        <MenuToggle onToggle={onToggle} />
-        <MobileMenuComponent show={showMobileMenu} />
+        <MenuToggle toggled={showMobileMenu} onToggle={onToggle} />
+        <MobileMenuComponent show={showMobileMenu} onClickLink={onToggle} />
       </UI.Content>
     </UI.Container>
   );
 }
 
-const MobileMenuComponent: React.FC<{ show: boolean }> = ({ show }) => {
+const MobileMenuComponent: React.FC<{ show: boolean, onClickLink: () => void }> = ({ show, onClickLink }) => {
   const router = useRouter();
 
   return (
     <UI.MobileMenuContainer show={show}>
-        {MOBILE_HEADER_LINKS.map((link) => link.component({ path: router.pathname }))}
+        {MOBILE_HEADER_LINKS.map((link) => link.component({ path: router.pathname, onClick: onClickLink }))}
         <UI.MobileCommunityLinks>
           {COMMUNITY_LINKS.map((link, idx) => (
             <UI.MobileCommunityLink key={idx} href={link.href} target="_blank">
@@ -60,24 +60,18 @@ const MobileMenuComponent: React.FC<{ show: boolean }> = ({ show }) => {
   );
 }
 
-const MenuToggle: React.FC<{ onToggle: (toggled: boolean) => void }> = ({ onToggle }) => {
-  const [toggled, setToggle] = useState(false);
-
-  const onClickToggle = () => {
-    setToggle((prevToggled) => {
-      onToggle(!prevToggled);
-      return !prevToggled;
-    });
-  }
-
+const MenuToggle: React.FC<{ toggled: boolean; onToggle: () => void }> = ({
+  toggled,
+  onToggle,
+}) => {
   return (
-    <UI.MenuToggleButton onClick={onClickToggle} toggled={toggled}>
+    <UI.MenuToggleButton onClick={onToggle} toggled={toggled}>
       <span></span>
       <span></span>
       <span></span>
     </UI.MenuToggleButton>
   );
-}
+};
 
 const CommunityDropdown: React.FunctionComponent = () => {
   return (
@@ -123,14 +117,18 @@ const HEADER_LINKS = [
   },
 ];
 
-const MOBILE_HEADER_LINKS = [
+interface IHeaderLink {
+  key: string;
+  component: (args: { path: string; onClick?: () => void }) => JSX.Element;
+}
+const MOBILE_HEADER_LINKS: IHeaderLink[] = [
   {
     key: "Projects",
     component: () => <UI.MobileNavLink href="https://projects.umaproject.org/">Projects</UI.MobileNavLink>,
   },
   {
     key: "Products",
-    component: ({ path }: { path: string }) => <UI.MobileNavLink href="/products" active={path === "/products"}>Products</UI.MobileNavLink>,
+    component: ({ path, onClick }) => <UI.MobileNavLink href="/products" active={path === "/products"} onClick={onClick}>Products</UI.MobileNavLink>,
   },
   {
     key: "Docs",

--- a/components/Link/index.tsx
+++ b/components/Link/index.tsx
@@ -9,17 +9,19 @@ const { QUERIES } = constants;
 type Props = React.PropsWithChildren<LinkProps> & {
   className?: string;
   target?: string;
+  onClick?: () => void;
 };
 export const Link: React.FC<Props> = ({
   children,
   className,
   target,
+  onClick,
   ...delegated
 }) => {
   const rel = target === "_blank" ? "noopener norefferer" : undefined;
   return (
     <NextLink {...delegated} passHref>
-      <StyledLink className={className} target={target} rel={rel}>
+      <StyledLink className={className} target={target} rel={rel} onClick={onClick}>
         {children}
       </StyledLink>
     </NextLink>


### PR DESCRIPTION
Signed-off-by: amateima <amatei@umaproject.org>

Close the mobile menu if the user clicks a link button. The mobile menu stayed opened when the url for the same page is clicked