### PR TITLE
feat(website): change careers link to lever

### DIFF
--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -18,7 +18,7 @@ const LINKS_LIST = [
     href: LINKS.getStarted,
   },
   { name: "Vote", href: LINKS.vote },
-  { name: "Careers", href: "https://angel.co/company/uma-project/jobs" },
+  { name: "Careers", href: "https://jobs.lever.co/umaproject" },
 ];
 
 const MAILCHIMP_URL =


### PR DESCRIPTION
Signed-off-by: ryanwolhuter <dev@ryanwolhuter.com>

**Motivation**

We have transitioned to Lever from Angel. Update the careers page link to take people there instead.

**Summary**

* Change the careers link to https://jobs.lever.co/umaproject